### PR TITLE
fixes excessive error logging due to recursive property checking and …

### DIFF
--- a/SmartSlicePlugin/stage/SmartSliceStage.py
+++ b/SmartSlicePlugin/stage/SmartSliceStage.py
@@ -111,7 +111,6 @@ class SmartSliceStage(CuraStage):
         controller = application.getController()
         extruderManager = application.getExtruderManager()
         extruderManager.activeExtruderChanged.connect(self.extruderChanged)
-        application.getMachineManager().activeMachine.propertyChanged.connect(self.extruderPropertyChanged)
 
         Selection.clear()
 
@@ -169,11 +168,8 @@ class SmartSliceStage(CuraStage):
 
         self._connector.updateSliceWidget()
 
-    def extruderPropertyChanged(self, key: str, property_name: str):
-        self.extruderChanged()
     # This creates the popup dialog that informs the user that only the
     # first extruder on a machine is currently supported.
-
     def extruderChanged(self):
         self._connector.smartSliceJobHandle.checkJob()
 


### PR DESCRIPTION
fixes ticket 169 and makes projects load in faster. All extruder properties were getting checked in SmartSliceStage and SmartSlicePropertyHandler. Taking out these lines will stop the recursive  checking if a property is changed and allow parts to be loaded in faster. All extruder checks are still properly working in SmartSlicePropertyHandler