### PR TITLE
R20.2 account link

### DIFF
--- a/SmartSlicePlugin/SmartSliceCloudProxy.py
+++ b/SmartSlicePlugin/SmartSliceCloudProxy.py
@@ -32,8 +32,10 @@ i18n_catalog = i18nCatalog("smartslice")
 
 # Serves as a bridge between the main UI in QML and data regarding Smart Slice
 class SmartSliceCloudProxy(QObject):
-    def __init__(self) -> None:
+    def __init__(self, metadata: "SmartSliceExtension.PluginMetaData") -> None:
         super().__init__()
+
+        self._metadata = metadata
 
         # Primary Button (Slice/Validate/Optimize)
         self._sliceStatusEnum = SmartSliceCloudStatus.Errors
@@ -170,6 +172,10 @@ class SmartSliceCloudProxy(QObject):
     resetResultsButtonsOpacity = pyqtSignal()
     unableToOptimizeStress = pyqtSignal()
     unableToOptimizeDisplacement = pyqtSignal()
+
+    @pyqtProperty(str, constant=True)
+    def accountUrl(self):
+        return self._metadata.account
 
     @pyqtProperty("QVariant", constant=True)
     def tooltipLocations(self):

--- a/SmartSlicePlugin/SmartSliceExtension.py
+++ b/SmartSlicePlugin/SmartSliceExtension.py
@@ -35,10 +35,13 @@ class SmartSliceExtension(Extension):
         self.metadata = PluginMetaData()
 
         # Proxy to the UI, and the cloud connector for the cloud
-        self.proxy = SmartSliceCloudProxy()
+        self.proxy = SmartSliceCloudProxy(self.metadata)
         self.cloud = SmartSliceCloudConnector(self.proxy, self)
 
         #self.setMenuName(i18n_catalog.i18nc("@item:inmenu", "Smart Slice"))
+
+        # Account management
+        self.addMenuItem(i18n_catalog.i18n("Account"), self._accountManagement)
 
         # Help links
         self.addMenuItem(i18n_catalog.i18n("Help"), self._openHelp)
@@ -90,6 +93,9 @@ class SmartSliceExtension(Extension):
     @staticmethod
     def _contactHelp():
         QDesktopServices.openUrl(QUrl("mailto:help@tetonsim.com?subject=Request for help with Smart Slice"))
+
+    def _accountManagement(self):
+        QDesktopServices.openUrl(QUrl(self.metadata.account))
 
     def _openAboutDialog(self):
         if not self._about_dialog:
@@ -303,6 +309,7 @@ class PluginMetaData:
         self.id = "SmartSlicePlugin"
         self.version = "N/A"
         self.url = "https://api.smartslice.xyz"
+        self.account = "https://account.tetonsim.com"
         self.cluster = None
 
         pluginMetaData = PluginMetaData.getMetadata()
@@ -311,6 +318,7 @@ class PluginMetaData:
             self.name = pluginMetaData.get("name", self.name)
             self.id = pluginMetaData.get("id", self.id)
             self.version = pluginMetaData.get("version", self.version)
+            self.account = pluginMetaData.get("smartSliceAccount", self.account)
 
             apiInfo = pluginMetaData.get("smartSliceApi", None)
 

--- a/SmartSlicePlugin/plugin.json
+++ b/SmartSlicePlugin/plugin.json
@@ -2,7 +2,7 @@
     "name": "Smart Slice",
     "id" : "SmartSlicePlugin",
     "author": "Teton Simulation, Inc.",
-    "version": "20.2.15",
+    "version": "20.2.16",
     "description": "Optimize and validate slice parameters to minimize print time while meeting end-use requirements.",
     "supported_sdk_versions": ["7.2.0", "7.3.0"],
     "i18n-catalog": "smartslice",

--- a/SmartSlicePlugin/plugin.json
+++ b/SmartSlicePlugin/plugin.json
@@ -9,5 +9,6 @@
     "smartSliceApi": {
         "url": "https://test.smartslice.xyz:443",
         "cluster": null
-    }
+    },
+    "smartSliceAccount": "https://account.test.smartslice.xyz/"
 }

--- a/SmartSlicePlugin/stage/ui/SmartSliceLogin.qml
+++ b/SmartSlicePlugin/stage/ui/SmartSliceLogin.qml
@@ -225,7 +225,7 @@ MouseArea {
                                 anchors.fill: parent
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: Qt.openUrlExternally('https://www.tetonsim.com/forgot-password')
+                                onClicked: Qt.openUrlExternally(smartSliceMain.proxy.accountUrl + '/forgot')
                             }
                         }
 

--- a/packaging/package.json
+++ b/packaging/package.json
@@ -9,7 +9,7 @@
     "display_name": "Smart Slice",
     "package_id": "SmartSlicePlugin",
     "package_type": "plugin",
-    "package_version": "20.2.15",
+    "package_version": "20.2.16",
     "sdk_version": 7,
     "sdk_version_semver": "7.0.0",
     "website": "https://www.tetonsim.com/smart-slice-for-cura"


### PR DESCRIPTION
- Added an "account" URL to plugin.json
- Added an "Account" option in the Smart Slice extension
- Changed the forgot password link to us the new account URL

I'd be interested to hear opinions on how this was architected. I had to get the plugin metadata from plugin.json over to the SmartSliceProxy in order to use it in the QML code, and I did so by just sending the metadata in the constructor for the proxy.